### PR TITLE
Add Benchmarks for Singleton

### DIFF
--- a/DesignPatternsInCSharp.Benchmarks/DesignPatternsInCSharp.Benchmarks.csproj
+++ b/DesignPatternsInCSharp.Benchmarks/DesignPatternsInCSharp.Benchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DesignPatternsInCSharp\DesignPatternsInCSharp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DesignPatternsInCSharp.Benchmarks/Program.cs
+++ b/DesignPatternsInCSharp.Benchmarks/Program.cs
@@ -1,0 +1,17 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace DesignPatternsInCSharp.Benchmarks
+{
+    internal static class Program
+    {
+        private static void Main(string[] arguments)
+        {
+            BenchmarkSwitcher benchmarkSwitcher = new BenchmarkSwitcher(
+                new[]
+                    {
+                        typeof(SingletonBenchmarks)
+                    });
+            benchmarkSwitcher.Run(arguments);
+        }
+    }
+}

--- a/DesignPatternsInCSharp.Benchmarks/SingletonBenchmarks.cs
+++ b/DesignPatternsInCSharp.Benchmarks/SingletonBenchmarks.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+namespace DesignPatternsInCSharp.Benchmarks
+{
+    [MeanColumn]
+    [MemoryDiagnoser]
+    [RankColumn]
+    public class SingletonBenchmarks
+    {
+        private ParallelOptions _parallelOptions;
+
+        private List<string> _strings;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _parallelOptions =
+                new ParallelOptions()
+                    {
+                        MaxDegreeOfParallelism = 3,
+                    };
+            _strings = new List<string>() { "one", "two", "three" };
+        }
+
+        [Benchmark(Baseline = true)]
+        public void Naive()
+        {
+            var instances = new List<Singleton.v1.Singleton>();
+
+            Parallel.ForEach(
+                _strings,
+                _parallelOptions,
+                _ => instances.Add(Singleton.v1.Singleton.Instance));
+        }
+
+        [Benchmark]
+        public void Locking()
+        {
+            var instances = new List<Singleton.v2.Singleton>();
+
+            Parallel.ForEach(
+                _strings,
+                _parallelOptions,
+                _ => instances.Add(Singleton.v2.Singleton.Instance));
+        }
+
+        [Benchmark]
+        public void BetterLocking()
+        {
+            var instances = new List<Singleton.v3.Singleton>();
+
+            Parallel.ForEach(
+                _strings,
+                _parallelOptions,
+                _ => instances.Add(Singleton.v3.Singleton.Instance));
+        }
+
+        [Benchmark]
+        public void LessLazy()
+        {
+            var instances = new List<Singleton.v4.Singleton>();
+
+            Parallel.ForEach(
+                _strings,
+                _parallelOptions,
+                _ => instances.Add(Singleton.v4.Singleton.Instance));
+        }
+
+        [Benchmark]
+        public void NestedLazy()
+        {
+            var instances = new List<Singleton.v5.Singleton>();
+
+            Parallel.ForEach(
+                _strings,
+                _parallelOptions,
+                _ => instances.Add(Singleton.v5.Singleton.Instance));
+        }
+
+        [Benchmark]
+        public void LazyOfT()
+        {
+            var instances = new List<Singleton.v6.Singleton>();
+
+            Parallel.ForEach(
+                _strings,
+                _parallelOptions,
+                _ => instances.Add(Singleton.v6.Singleton.Instance));
+        }
+    }
+}

--- a/DesignPatternsInCSharp.Benchmarks/SingletonBenchmarks.cs
+++ b/DesignPatternsInCSharp.Benchmarks/SingletonBenchmarks.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using BenchmarkDotNet.Attributes;
@@ -28,67 +29,67 @@ namespace DesignPatternsInCSharp.Benchmarks
         [Benchmark(Baseline = true)]
         public void Naive()
         {
-            var instances = new List<Singleton.v1.Singleton>();
+            var instances = new ConcurrentDictionary<Singleton.v1.Singleton, byte>();
 
             Parallel.ForEach(
                 _strings,
                 _parallelOptions,
-                _ => instances.Add(Singleton.v1.Singleton.Instance));
+                _ => instances.TryAdd(Singleton.v1.Singleton.Instance, 0));
         }
 
         [Benchmark]
         public void Locking()
         {
-            var instances = new List<Singleton.v2.Singleton>();
+            var instances = new ConcurrentDictionary<Singleton.v2.Singleton, byte>();
 
             Parallel.ForEach(
                 _strings,
                 _parallelOptions,
-                _ => instances.Add(Singleton.v2.Singleton.Instance));
+                _ => instances.TryAdd(Singleton.v2.Singleton.Instance, 0));
         }
 
         [Benchmark]
         public void BetterLocking()
         {
-            var instances = new List<Singleton.v3.Singleton>();
+            var instances = new ConcurrentDictionary<Singleton.v3.Singleton, byte>();
 
             Parallel.ForEach(
                 _strings,
                 _parallelOptions,
-                _ => instances.Add(Singleton.v3.Singleton.Instance));
+                _ => instances.TryAdd(Singleton.v3.Singleton.Instance, 0));
         }
 
         [Benchmark]
         public void LessLazy()
         {
-            var instances = new List<Singleton.v4.Singleton>();
+            var instances = new ConcurrentDictionary<Singleton.v4.Singleton, byte>();
 
             Parallel.ForEach(
                 _strings,
                 _parallelOptions,
-                _ => instances.Add(Singleton.v4.Singleton.Instance));
+                _ => instances.TryAdd(Singleton.v4.Singleton.Instance, 0));
         }
 
         [Benchmark]
         public void NestedLazy()
         {
-            var instances = new List<Singleton.v5.Singleton>();
+            var instances = new ConcurrentDictionary<Singleton.v5.Singleton, byte>();
 
             Parallel.ForEach(
                 _strings,
                 _parallelOptions,
-                _ => instances.Add(Singleton.v5.Singleton.Instance));
+                _ => instances.TryAdd(Singleton.v5.Singleton.Instance, 0));
         }
 
         [Benchmark]
         public void LazyOfT()
         {
-            var instances = new List<Singleton.v6.Singleton>();
+            var instances = new ConcurrentDictionary<Singleton.v6.Singleton, byte>();
 
             Parallel.ForEach(
                 _strings,
                 _parallelOptions,
-                _ => instances.Add(Singleton.v6.Singleton.Instance));
+                _ => instances.TryAdd(Singleton.v6.Singleton.Instance, 0));
         }
     }
 }

--- a/DesignPatternsInCSharp.sln
+++ b/DesignPatternsInCSharp.sln
@@ -10,7 +10,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GreeterService", "GreeterService\GreeterService.csproj", "{1F527722-FD31-4DC4-9FC9-8F259724107D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GreeterService", "GreeterService\GreeterService.csproj", "{1F527722-FD31-4DC4-9FC9-8F259724107D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DesignPatternsInCSharp.Benchmarks", "DesignPatternsInCSharp.Benchmarks\DesignPatternsInCSharp.Benchmarks.csproj", "{D6F7EB79-9204-4062-A3EB-EC001F60ECAB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,6 +28,10 @@ Global
 		{1F527722-FD31-4DC4-9FC9-8F259724107D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1F527722-FD31-4DC4-9FC9-8F259724107D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1F527722-FD31-4DC4-9FC9-8F259724107D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6F7EB79-9204-4062-A3EB-EC001F60ECAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6F7EB79-9204-4062-A3EB-EC001F60ECAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6F7EB79-9204-4062-A3EB-EC001F60ECAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6F7EB79-9204-4062-A3EB-EC001F60ECAB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DesignPatternsInCSharp/Singleton/README.md
+++ b/DesignPatternsInCSharp/Singleton/README.md
@@ -1,0 +1,96 @@
+﻿# Singleton
+
+## Benchmarks
+
+The Singleton implementations can be benchmarked using [BenchmarkDotNet](https://benchmarkdotnet.org/).
+
+
+
+The benchmark implementation follows the Parallel unit tests but alters them slightly to isolate what is being measured.
+
+```cs
+[Benchmark(Baseline = true)]
+public void Naive()
+{
+    var instances = new ConcurrentDictionary<Singleton.v1.Singleton, byte>();
+
+    Parallel.ForEach(
+        _strings,
+        _parallelOptions,
+        _ => instances.TryAdd(Singleton.v1.Singleton.Instance, 0));
+}
+```
+
+A `ConcurrentDictionary` is used to ensure adding the instance to the collection is thread-safe for accurate allocation information.
+
+### Building
+
+The Benchmark project can be built and run from Visual Studio, although it is [recommended](https://benchmarkdotnet.org/articles/guides/good-practices.html) to run without to get the best results.
+
+To build the Benchmark project from the command line use:
+
+```sh
+dotnet build -c Release
+```
+
+Or using MSBuild:
+
+```sh
+msbuild /t:Rebuild /p:Configuration=Release
+```
+
+> If you are having difficulty locating the `msbuild` executable, check the Visual Studio installation directory. 
+> For example, `%PROGRAMFILES(X86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin`
+
+### Running
+
+Once built, run the console application:
+```sh
+DesignPatternsInCSharp.Benchmarks.exe
+```
+
+[Arguments](https://benchmarkdotnet.org/articles/guides/console-args.html) can be provided to the application if desired.
+
+The console will display something similar to:
+
+> Available Benchmark:
+>  #0 SingletonBenchmarks
+>
+>
+> You should select the target benchmark(s). Please, print a number of a benchmark (e.g. `0`) or a contained benchmark caption (e.g. `SingletonBenchmarks`).
+> If you want to select few, please separate them with space ` ` (e.g. `1 2 3`).
+> You can also provide the class name in console arguments by using --filter. (e.g. `--filter *SingletonBenchmarks*`).
+
+### Results
+
+Once run, the application will output the results to the console:
+
+> BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18362.778 (1903/May2019Update/19H1)
+> Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+> .NET Core SDK=3.1.201
+>   [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
+>   DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
+> 
+> 
+> |        Method |     Mean |     Error |    StdDev | Ratio | RatioSD | Rank |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
+> |-------------- |---------:|----------:|----------:|------:|--------:|-----:|-------:|-------:|------:|----------:|
+> |         Naive | 5.069 us | 0.1715 us | 0.5029 us |  1.00 |    0.00 |    2 | 0.6065 | 0.0038 |     - |   2.78 KB |
+> |       Locking | 4.733 us | 0.0846 us | 0.1505 us |  0.89 |    0.07 |    1 | 0.6027 |      - |     - |    2.9 KB |
+> | BetterLocking | 4.713 us | 0.0926 us | 0.0909 us |  0.86 |    0.07 |    1 | 0.6027 |      - |     - |   2.78 KB |
+> |      LessLazy | 4.607 us | 0.0668 us | 0.0592 us |  0.84 |    0.07 |    1 | 0.6027 |      - |     - |   2.78 KB |
+> |    NestedLazy | 4.679 us | 0.0878 us | 0.0822 us |  0.85 |    0.08 |    1 | 0.6027 |      - |     - |    2.9 KB |
+> |       LazyOfT | 4.629 us | 0.0669 us | 0.0625 us |  0.84 |    0.07 |    1 | 0.6027 |      - |     - |   2.78 KB |
+
+Note that different frameworks may yield different results.
+See [Unrolling of small loops in different JIT versions](https://aakinshin.net/posts/unrolling-of-small-loops-in-different-jit-versions/) from [Awesome dotnet Performance](https://github.com/adamsitnik/awesome-dot-net-performance) for an example of this.
+
+These results show that the `Naive` implementation allocates more in `Gen 0` while the other benchmarks do not. 
+This is due to the implementation not being thread-safe.
+
+Interestingly, the thread-safe implementations have a variable total amount of allocations.
+Initial thoughts were that this was because of the `lockpad` object, but the results differ for `Locking` and `BetterLocking`.
+The `IL` would need to be analyzed further to check for differences in the generated code.
+
+The best implementations in terms of speed and allocation is the `LessLazy` and `LazyOfT` implementations.
+Keep in mind that the `LessLazy` implementation does not lazily initialize if multiple `static` fields are used.
+For this reason, the best implementation in terms of speed and allocation is the `LazyOfT` implementation.


### PR DESCRIPTION
Wanted to see what each method costs to try to determine the best one to use in specific situations.

Build the project in Release and run the Console application selecting the Benchmark to run.

My machine generated the following results:

|        Method |     Mean |     Error |    StdDev |   Median | Ratio | RatioSD | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |---------:|----------:|----------:|---------:|------:|--------:|-----:|-------:|------:|------:|----------:|
|         Naive | 4.524 us | 0.0869 us | 0.2013 us | 4.461 us |  1.00 |    0.00 |    1 | 0.4387 |     - |     - |   2.07 KB |
|       Locking | 4.718 us | 0.1331 us | 0.3882 us | 4.599 us |  1.06 |    0.10 |    1 | 0.4349 |     - |     - |   2.13 KB |
| BetterLocking | 4.664 us | 0.1016 us | 0.2965 us | 4.608 us |  1.04 |    0.08 |    1 | 0.4349 |     - |     - |   2.14 KB |
|      LessLazy | 4.655 us | 0.0978 us | 0.2791 us | 4.575 us |  1.03 |    0.08 |    1 | 0.4349 |     - |     - |   2.14 KB |
|    NestedLazy | 4.613 us | 0.1136 us | 0.3278 us | 4.515 us |  1.03 |    0.08 |    1 | 0.4349 |     - |     - |   2.13 KB |
|       LazyOfT | 4.613 us | 0.1065 us | 0.3088 us | 4.538 us |  1.02 |    0.08 |    1 | 0.4349 |     - |     - |   2.01 KB |

As expected, Naive allocates more and is faster than locking. Surprisingly though Locking and Better locking allocate more (perhaps because of the `lockpad` initialization?). LazyOfT performed the best in both mean time and allocations and should be the recommended method of locking - supporting the conclusions in your course.